### PR TITLE
e2e: follow-up to default memory change

### DIFF
--- a/docs/modules/getting_started/partials/proc_configuring-the-instance.adoc
+++ b/docs/modules/getting_started/partials/proc_configuring-the-instance.adoc
@@ -41,7 +41,7 @@ Values for available memory are set in mebibytes (MiB).
 One gibibyte (GiB) of memory is equal to 1024 MiB.
 ====
 +
-The default value for the `memory` property is `9216`.
+The default value for the `memory` property is `10752`.
 The amount of memory to assign must be greater than or equal to the default.
 
 * To start the instance with the desired amount of memory:

--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -223,7 +223,7 @@ func TestConfigGetMultiple(t *testing.T) {
 		apiClient.GetConfigResult{
 			Configs: map[string]interface{}{
 				"cpus":   float64(4),
-				"memory": float64(9216),
+				"memory": float64(10752),
 			},
 		},
 		configGetMultiplePropertyResult,

--- a/pkg/crc/config/settings_test.go
+++ b/pkg/crc/config/settings_test.go
@@ -78,10 +78,10 @@ func TestSetPreset(t *testing.T) {
 
 	_, err = cfg.Set(Preset, crcpreset.Podman)
 	require.NoError(t, err)
-	_, err = cfg.Set(Memory, 10000)
+	_, err = cfg.Set(Memory, 10800)
 	require.NoError(t, err)
 	assert.Equal(t, SettingValue{
-		Value:     10000,
+		Value:     10800,
 		Invalid:   false,
 		IsDefault: false,
 		IsSecret:  false,
@@ -99,7 +99,7 @@ func TestSetPreset(t *testing.T) {
 	_, err = cfg.Set(Preset, crcpreset.OpenShift)
 	require.NoError(t, err)
 	assert.Equal(t, SettingValue{
-		Value:     10000,
+		Value:     10800,
 		Invalid:   false,
 		IsDefault: false,
 		IsSecret:  false,
@@ -120,10 +120,10 @@ func TestUnsetPreset(t *testing.T) {
 
 	_, err = cfg.Set(Preset, crcpreset.Podman)
 	require.NoError(t, err)
-	_, err = cfg.Set(Memory, 10000)
+	_, err = cfg.Set(Memory, 10800)
 	require.NoError(t, err)
 	assert.Equal(t, SettingValue{
-		Value:     10000,
+		Value:     10800,
 		Invalid:   false,
 		IsDefault: false,
 		IsSecret:  false,
@@ -147,7 +147,7 @@ func TestUnsetPreset(t *testing.T) {
 		IsSecret:  false,
 	}, cfg.Get(Preset))
 	assert.Equal(t, SettingValue{
-		Value:     10000,
+		Value:     10800,
 		Invalid:   false,
 		IsDefault: false,
 		IsSecret:  false,

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -216,14 +216,14 @@ func GetDefaultCPUs(preset crcpreset.Preset) int {
 func GetDefaultMemory(preset crcpreset.Preset) int {
 	switch preset {
 	case crcpreset.OpenShift, crcpreset.OKD:
-		return 9216
+		return 10752
 	case crcpreset.Podman:
 		return 2048
 	case crcpreset.Microshift:
 		return 4096
 	default:
 		// should not be reached
-		return 9216
+		return 10752
 	}
 }
 

--- a/pkg/libmachine/host/migrate_test.go
+++ b/pkg/libmachine/host/migrate_test.go
@@ -17,7 +17,7 @@ func TestLoadHost(t *testing.T) {
         "IPAddress": "192.168.130.11",
         "MachineName": "crc",
         "BundleName": "crc_libvirt_4.6.6.crcbundle",
-        "Memory": 9216,
+        "Memory": 10752,
         "CPU": 4
     }`
 

--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -2,7 +2,8 @@
 Feature: 4 Openshift stories
 
 	Background:
-		Given ensuring CRC cluster is running
+		Given setting config property "disk-size" to value "40" succeeds
+		And ensuring CRC cluster is running
 		And ensuring oc command is available
 		And ensuring user is logged in succeeds
 

--- a/test/integration/proxy_test.go
+++ b/test/integration/proxy_test.go
@@ -67,7 +67,7 @@ var _ = Describe("", Serial, Ordered, Label("openshift-preset", "goproxy"), func
 		})
 
 		It("start CRC", func() {
-			// default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
+			// default values: "--memory", "10752", "--cpus", "4", "disk-size", "31"
 			if bundlePath == "" {
 				Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
 			} else {

--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -34,7 +34,7 @@ var _ = Describe("vary VM parameters: memory cpus, disk", Serial, Ordered, Label
 		})
 
 		It("start CRC", func() {
-			// default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
+			// default values: "--memory", "10752", "--cpus", "4", "disk-size", "31"
 			if bundlePath == "" {
 				Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "5", "--disk-size", "40", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
 			} else {
@@ -118,8 +118,8 @@ var _ = Describe("vary VM parameters: memory cpus, disk", Serial, Ordered, Label
 
 	Describe("use flawed values", Serial, Ordered, func() {
 
-		It("start CRC with sub-minimum memory", func() { // less than min = 9216
-			Expect(RunCRCExpectFail("start", "--memory", "9000")).To(ContainSubstring("requires memory in MiB >= 9216"))
+		It("start CRC with sub-minimum memory", func() { // less than min = 10752
+			Expect(RunCRCExpectFail("start", "--memory", "9000")).To(ContainSubstring("requires memory in MiB >= 10752"))
 		})
 		It("start CRC with sub-minimum cpus", func() { // fewer than min
 			Expect(RunCRCExpectFail("start", "--cpus", "3")).To(ContainSubstring("requires CPUs >= 4"))
@@ -139,13 +139,13 @@ var _ = Describe("vary VM parameters: memory cpus, disk", Serial, Ordered, Label
 	Describe("use default values again", Serial, Ordered, func() {
 
 		It("start CRC", func() {
-			Expect(RunCRCExpectSuccess("start")).To(ContainSubstring("Started the OpenShift cluster")) // default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
+			Expect(RunCRCExpectSuccess("start")).To(ContainSubstring("Started the OpenShift cluster")) // default values: "--memory", "10752", "--cpus", "4", "disk-size", "31"
 		})
 
 		It("check VM's memory size", func() {
 			out, err := util.SendCommandToVM("cat /proc/meminfo")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`)) // there should be a check if cluster needs >9216MiB; it isn't there and mem gets scaled down regardless
+			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`)) // there should be a check if cluster needs >10752MiB; it isn't there and mem gets scaled down regardless
 		})
 
 		It("check VM's number of cpus", func() {


### PR DESCRIPTION
Hey Praveen! 

I'm sending a commit with a change that might be needed after transition to 10GiB RAM. Integration won't pass otherwise. Use as you like :). 

Thanks!